### PR TITLE
Java 25 / WildFly 40 spike: cp-microservice-framework

### DIFF
--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -31,7 +31,7 @@ resources:
 pool:
   name: 'MDV-ADO-AGENT-AKS-01'
   demands:
-    - identifier -equals ubuntu-j21
+    - identifier -equals ubuntu-j25-postgres
  
 variables:
   - name: sonarqubeProject

--- a/common-rest/pom.xml
+++ b/common-rest/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>microservice-framework</artifactId>
         <groupId>uk.gov.justice.services</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>microservice-framework</artifactId>
         <groupId>uk.gov.justice.services</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/components/custom/pom.xml
+++ b/components/custom/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>components</artifactId>
         <groupId>uk.gov.justice.services</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/components/pom.xml
+++ b/components/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>microservice-framework</artifactId>
         <groupId>uk.gov.justice.services</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>microservice-framework</artifactId>
         <groupId>uk.gov.justice.services</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/event-subscription-test-utils/pom.xml
+++ b/event-subscription-test-utils/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>microservice-framework</artifactId>
         <groupId>uk.gov.justice.services</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/event-subscription/pom.xml
+++ b/event-subscription/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>microservice-framework</artifactId>
         <groupId>uk.gov.justice.services</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/framework-bom/pom.xml
+++ b/framework-bom/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>microservice-framework</artifactId>
         <groupId>uk.gov.justice.services</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/framework-generators/direct-adapter-core/pom.xml
+++ b/framework-generators/direct-adapter-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>framework-generators</artifactId>
         <groupId>uk.gov.justice.framework-generators</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/framework-generators/direct-client-generator-plugin/pom.xml
+++ b/framework-generators/direct-client-generator-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>framework-generators</artifactId>
         <groupId>uk.gov.justice.framework-generators</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/framework-generators/direct-client-generator/pom.xml
+++ b/framework-generators/direct-client-generator/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>framework-generators</artifactId>
         <groupId>uk.gov.justice.framework-generators</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/framework-generators/direct-client-generator/pom.xml
+++ b/framework-generators/direct-client-generator/pom.xml
@@ -57,11 +57,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.glassfish</groupId>
-            <artifactId>jakarta.json</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.eclipse.parsson</groupId>
             <artifactId>parsson</artifactId>
             <scope>test</scope>

--- a/framework-generators/generators-commons/pom.xml
+++ b/framework-generators/generators-commons/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>uk.gov.justice.framework-generators</groupId>
         <artifactId>framework-generators</artifactId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/framework-generators/generators-commons/src/test/java/uk/gov/justice/services/generators/commons/mapping/ActionNameToMediaTypesMapperClassBuilderTest.java
+++ b/framework-generators/generators-commons/src/test/java/uk/gov/justice/services/generators/commons/mapping/ActionNameToMediaTypesMapperClassBuilderTest.java
@@ -77,14 +77,12 @@ public class ActionNameToMediaTypesMapperClassBuilderTest {
 
     private Class<?> writeSourceFileAndCompile(final String packageName, final TypeSpec typeSpec) throws IOException {
 
-        final File outputFolderRoot = outputFolder.getParentFile();
-
         JavaFile.builder(packageName, typeSpec)
                 .build()
-                .writeTo(outputFolderRoot);
+                .writeTo(outputFolder);
 
         return javaCompilerUtil()
-                .compiledClassesOf(outputFolderRoot, outputFolderRoot, packageName)
+                .compiledClassesOf(outputFolder, outputFolder, packageName)
                 .stream()
                 .filter(clazz -> !clazz.getName().equals("java.lang.Object"))
                 .findFirst().orElseGet(null);

--- a/framework-generators/generators-commons/src/test/java/uk/gov/justice/services/generators/commons/mapping/RamlMediaTypeToSchemaIdMapperClassBuilderTest.java
+++ b/framework-generators/generators-commons/src/test/java/uk/gov/justice/services/generators/commons/mapping/RamlMediaTypeToSchemaIdMapperClassBuilderTest.java
@@ -87,15 +87,12 @@ public class RamlMediaTypeToSchemaIdMapperClassBuilderTest {
     @SuppressWarnings("ConstantConditions")
     private Class<?> writeSourceFileAndCompile(final String packageName, final TypeSpec typeSpec) throws IOException {
 
-        final File outputFolderRoot = outputFolder.getParentFile();
-
         JavaFile.builder(packageName, typeSpec)
                 .build()
-                .writeTo(outputFolderRoot);
-
+                .writeTo(outputFolder);
 
         return javaCompilerUtil()
-                .compiledClassesOf(outputFolderRoot, outputFolderRoot, packageName)
+                .compiledClassesOf(outputFolder, outputFolder, packageName)
                 .stream()
                 .filter(clazz -> !clazz.getName().equals("java.lang.Object"))
                 .findFirst().orElseGet(null);

--- a/framework-generators/generators-commons/src/test/java/uk/gov/justice/services/generators/commons/mapping/SubscriptionMediaTypeToSchemaIdMapperClassBuilderTest.java
+++ b/framework-generators/generators-commons/src/test/java/uk/gov/justice/services/generators/commons/mapping/SubscriptionMediaTypeToSchemaIdMapperClassBuilderTest.java
@@ -106,15 +106,12 @@ public class SubscriptionMediaTypeToSchemaIdMapperClassBuilderTest {
     @SuppressWarnings("ConstantConditions")
     private Class<?> writeSourceFileAndCompile(final String packageName, final TypeSpec typeSpec) throws IOException {
 
-        final File outputFolderRoot = outputFolder.getParentFile();
-
         JavaFile.builder(packageName, typeSpec)
                 .build()
-                .writeTo(outputFolderRoot);
-
+                .writeTo(outputFolder);
 
         return javaCompilerUtil()
-                .compiledClassesOf(outputFolderRoot, outputFolderRoot, packageName)
+                .compiledClassesOf(outputFolder, outputFolder, packageName)
                 .stream()
                 .filter(clazz -> !clazz.getName().equals("java.lang.Object"))
                 .findFirst().orElseGet(null);

--- a/framework-generators/generators-subscription/pom.xml
+++ b/framework-generators/generators-subscription/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>framework-generators</artifactId>
         <groupId>uk.gov.justice.framework-generators</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/framework-generators/generators-test-utils/pom.xml
+++ b/framework-generators/generators-test-utils/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>framework-generators</artifactId>
         <groupId>uk.gov.justice.framework-generators</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/framework-generators/generators-test-utils/src/main/java/uk/gov/justice/services/generators/test/utils/builder/HeadersBuilder.java
+++ b/framework-generators/generators-test-utils/src/main/java/uk/gov/justice/services/generators/test/utils/builder/HeadersBuilder.java
@@ -6,6 +6,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import jakarta.ws.rs.core.Cookie;
@@ -72,6 +73,15 @@ public class HeadersBuilder {
             @Override
             public int getLength() {
                 return -1;
+            }
+
+            @Override
+            public boolean containsHeaderString(final String name, final String valueSeparatorRegex, final Predicate<String> valuePredicate) {
+                final List<String> values = headersMap.getOrDefault(name, Collections.emptyList());
+                return values.stream()
+                        .flatMap(v -> java.util.Arrays.stream(v.split(valueSeparatorRegex)))
+                        .map(String::trim)
+                        .anyMatch(valuePredicate);
             }
         };
     }

--- a/framework-generators/generators-test-utils/src/test/java/uk/gov/justice/services/generators/test/utils/builder/HeadersBuilderTest.java
+++ b/framework-generators/generators-test-utils/src/test/java/uk/gov/justice/services/generators/test/utils/builder/HeadersBuilderTest.java
@@ -1,0 +1,39 @@
+package uk.gov.justice.services.generators.test.utils.builder;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static uk.gov.justice.services.generators.test.utils.builder.HeadersBuilder.headersWith;
+
+import jakarta.ws.rs.core.HttpHeaders;
+import org.junit.jupiter.api.Test;
+
+public class HeadersBuilderTest {
+
+    @Test
+    public void shouldReturnTrueWhenHeaderValueMatchesPredicate() {
+        final HttpHeaders headers = headersWith("Accept-Encoding", "gzip");
+
+        assertThat(headers.containsHeaderString("Accept-Encoding", ",", "gzip"::equals), is(true));
+    }
+
+    @Test
+    public void shouldReturnFalseWhenHeaderValueDoesNotMatchPredicate() {
+        final HttpHeaders headers = headersWith("Accept-Encoding", "gzip");
+
+        assertThat(headers.containsHeaderString("Accept-Encoding", ",", "deflate"::equals), is(false));
+    }
+
+    @Test
+    public void shouldReturnFalseWhenHeaderNotPresent() {
+        final HttpHeaders headers = headersWith("Content-Type", "application/json");
+
+        assertThat(headers.containsHeaderString("Accept-Encoding", ",", "gzip"::equals), is(false));
+    }
+
+    @Test
+    public void shouldSplitMultipleValuesBySeparatorAndMatchAfterTrim() {
+        final HttpHeaders headers = headersWith("Accept-Encoding", "gzip, deflate");
+
+        assertThat(headers.containsHeaderString("Accept-Encoding", ",", "deflate"::equals), is(true));
+    }
+}

--- a/framework-generators/messaging-adapter-core/pom.xml
+++ b/framework-generators/messaging-adapter-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>framework-generators</artifactId>
         <groupId>uk.gov.justice.framework-generators</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/framework-generators/messaging-adapter-generator-plugin/pom.xml
+++ b/framework-generators/messaging-adapter-generator-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>framework-generators</artifactId>
         <groupId>uk.gov.justice.framework-generators</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/framework-generators/messaging-adapter-generator/pom.xml
+++ b/framework-generators/messaging-adapter-generator/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>framework-generators</artifactId>
         <groupId>uk.gov.justice.framework-generators</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <artifactId>messaging-adapter-generator</artifactId>
     <dependencies>
@@ -113,15 +113,15 @@
             <scope>test</scope>
             <exclusions>
                 <exclusion>
-                    <groupId>org.apache.activemq</groupId>
+                    <groupId>org.apache.artemis</groupId>
                     <artifactId>activemq-ra</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>org.apache.activemq</groupId>
+                    <groupId>org.apache.artemis</groupId>
                     <artifactId>activemq-broker</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>org.apache.activemq</groupId>
+                    <groupId>org.apache.artemis</groupId>
                     <artifactId>activemq-jdbc-store</artifactId>
                 </exclusion>
                 <exclusion>
@@ -146,23 +146,23 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-jms-client</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-service-extensions</artifactId>
             <exclusions>
                 <exclusion>
-                    <groupId>org.apache.activemq</groupId>
+                    <groupId>org.apache.artemis</groupId>
                     <artifactId>artemis-jms-client</artifactId>
                 </exclusion>
             </exclusions>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-ra</artifactId>
             <scope>test</scope>
         </dependency>

--- a/framework-generators/messaging-client-generator-plugin/pom.xml
+++ b/framework-generators/messaging-client-generator-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>framework-generators</artifactId>
         <groupId>uk.gov.justice.framework-generators</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/framework-generators/messaging-client-generator/pom.xml
+++ b/framework-generators/messaging-client-generator/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>framework-generators</artifactId>
         <groupId>uk.gov.justice.framework-generators</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/framework-generators/messaging-client-generator/pom.xml
+++ b/framework-generators/messaging-client-generator/pom.xml
@@ -94,11 +94,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.glassfish</groupId>
-            <artifactId>jakarta.json</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.eclipse.parsson</groupId>
             <artifactId>parsson</artifactId>
             <scope>test</scope>

--- a/framework-generators/pom.xml
+++ b/framework-generators/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>microservice-framework</artifactId>
         <groupId>uk.gov.justice.services</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/framework-generators/rest-adapter-core/pom.xml
+++ b/framework-generators/rest-adapter-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>framework-generators</artifactId>
         <groupId>uk.gov.justice.framework-generators</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>rest-adapter-core</artifactId>

--- a/framework-generators/rest-adapter-file-service/pom.xml
+++ b/framework-generators/rest-adapter-file-service/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>framework-generators</artifactId>
         <groupId>uk.gov.justice.framework-generators</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/framework-generators/rest-adapter-generator-plugin/pom.xml
+++ b/framework-generators/rest-adapter-generator-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>framework-generators</artifactId>
         <groupId>uk.gov.justice.framework-generators</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/framework-generators/rest-adapter-generator/pom.xml
+++ b/framework-generators/rest-adapter-generator/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>framework-generators</artifactId>
         <groupId>uk.gov.justice.framework-generators</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/framework-generators/rest-adapter-generator/pom.xml
+++ b/framework-generators/rest-adapter-generator/pom.xml
@@ -61,11 +61,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.glassfish</groupId>
-            <artifactId>jakarta.json</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.eclipse.parsson</groupId>
             <artifactId>parsson</artifactId>
             <scope>test</scope>

--- a/framework-generators/rest-client-core/pom.xml
+++ b/framework-generators/rest-client-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>framework-generators</artifactId>
         <groupId>uk.gov.justice.framework-generators</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
 
     <artifactId>rest-client-core</artifactId>

--- a/framework-generators/rest-client-generator-plugin/pom.xml
+++ b/framework-generators/rest-client-generator-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>framework-generators</artifactId>
         <groupId>uk.gov.justice.framework-generators</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/framework-generators/rest-client-generator/pom.xml
+++ b/framework-generators/rest-client-generator/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>framework-generators</artifactId>
         <groupId>uk.gov.justice.framework-generators</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
 
     <artifactId>rest-client-generator</artifactId>

--- a/framework-generators/unifiedsearch-client-generator-plugin/pom.xml
+++ b/framework-generators/unifiedsearch-client-generator-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>framework-generators</artifactId>
         <groupId>uk.gov.justice.framework-generators</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/framework-generators/unifiedsearch-client-generator/pom.xml
+++ b/framework-generators/unifiedsearch-client-generator/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>framework-generators</artifactId>
         <groupId>uk.gov.justice.framework-generators</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/framework-generators/unifiedsearch-core/pom.xml
+++ b/framework-generators/unifiedsearch-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>framework-generators</artifactId>
         <groupId>uk.gov.justice.framework-generators</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/framework-jmx-command-client/pom.xml
+++ b/framework-jmx-command-client/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <artifactId>microservice-framework</artifactId>
         <groupId>uk.gov.justice.services</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
 
     <artifactId>framework-jmx-command-client</artifactId>

--- a/framework-system/framework-healthcheck/pom.xml
+++ b/framework-system/framework-healthcheck/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>framework-system</artifactId>
         <groupId>uk.gov.justice.services</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/framework-system/framework-management/pom.xml
+++ b/framework-system/framework-management/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>framework-system</artifactId>
         <groupId>uk.gov.justice.services</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/framework-system/framework-system-liquibase/pom.xml
+++ b/framework-system/framework-system-liquibase/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>framework-system</artifactId>
         <groupId>uk.gov.justice.services</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/framework-system/pom.xml
+++ b/framework-system/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>microservice-framework</artifactId>
         <groupId>uk.gov.justice.services</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/framework-system/shuttering-persistence/pom.xml
+++ b/framework-system/shuttering-persistence/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>framework-system</artifactId>
         <groupId>uk.gov.justice.services</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -45,42 +45,53 @@
     </dependencies>
 
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.liquibase</groupId>
-                <artifactId>liquibase-maven-plugin</artifactId>
-                <version>${liquibase.version}</version>
-                <configuration>
-                    <changeLogFile>liquibase/framework-system-changelog.xml</changeLogFile>
-                    <driver>org.postgresql.Driver</driver>
-                    <url>jdbc:postgresql://localhost:5432/frameworksystem</url>
-                    <username>framework</username>
-                    <password>framework</password>
-                </configuration>
-                <executions>
-                    <execution>
-                        <phase>pre-integration-test</phase>
-                        <goals>
-                            <goal>dropAll</goal>
-                            <goal>update</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <dependencies>
-                    <dependency>
-                        <groupId>uk.gov.justice.services</groupId>
-                        <artifactId>framework-system-liquibase</artifactId>
-                        <version>${project.version}</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>org.postgresql</groupId>
-                        <artifactId>postgresql</artifactId>
-                        <version>${postgresql.driver.version}</version>
-                    </dependency>
-                </dependencies>
-            </plugin>
-        </plugins>
-    </build>
+    <profiles>
+        <profile>
+            <id>integration-tests</id>
+            <activation>
+                <property>
+                    <name>run.it</name>
+                    <value>!false</value>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.liquibase</groupId>
+                        <artifactId>liquibase-maven-plugin</artifactId>
+                        <version>${liquibase.maven.plugin.version}</version>
+                        <configuration>
+                            <changeLogFile>liquibase/framework-system-changelog.xml</changeLogFile>
+                            <driver>org.postgresql.Driver</driver>
+                            <url>jdbc:postgresql://localhost:5432/frameworksystem</url>
+                            <username>framework</username>
+                            <password>framework</password>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <phase>pre-integration-test</phase>
+                                <goals>
+                                    <goal>dropAll</goal>
+                                    <goal>update</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <dependencies>
+                            <dependency>
+                                <groupId>uk.gov.justice.services</groupId>
+                                <artifactId>framework-system-liquibase</artifactId>
+                                <version>${project.version}</version>
+                            </dependency>
+                            <dependency>
+                                <groupId>org.postgresql</groupId>
+                                <artifactId>postgresql</artifactId>
+                                <version>${postgresql.driver.version}</version>
+                            </dependency>
+                        </dependencies>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
 </project>

--- a/framework-utilities/pom.xml
+++ b/framework-utilities/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>microservice-framework</artifactId>
         <groupId>uk.gov.justice.services</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/jmx/jmx-api/pom.xml
+++ b/jmx/jmx-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>jmx</artifactId>
         <groupId>uk.gov.justice.services</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/jmx/jmx-command-client/pom.xml
+++ b/jmx/jmx-command-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>jmx</artifactId>
         <groupId>uk.gov.justice.services</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/jmx/jmx-command-handling/pom.xml
+++ b/jmx/jmx-command-handling/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>jmx</artifactId>
         <groupId>uk.gov.justice.services</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/jmx/pom.xml
+++ b/jmx/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>microservice-framework</artifactId>
         <groupId>uk.gov.justice.services</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/messaging/messaging-core/pom.xml
+++ b/messaging/messaging-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>messaging</artifactId>
         <groupId>uk.gov.justice.services</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/messaging/messaging-jms/pom.xml
+++ b/messaging/messaging-jms/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>messaging</artifactId>
         <groupId>uk.gov.justice.services</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/messaging/pom.xml
+++ b/messaging/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>microservice-framework</artifactId>
         <groupId>uk.gov.justice.services</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/metrics/metrics-interceptor/pom.xml
+++ b/metrics/metrics-interceptor/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>metrics</artifactId>
         <groupId>uk.gov.justice.metrics</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/metrics/metrics-micrometer-core/pom.xml
+++ b/metrics/metrics-micrometer-core/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>uk.gov.justice.metrics</groupId>
         <artifactId>metrics</artifactId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
 
     <artifactId>metrics-micrometer-core</artifactId>

--- a/metrics/metrics-servlet/pom.xml
+++ b/metrics/metrics-servlet/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>metrics</artifactId>
         <groupId>uk.gov.justice.metrics</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/metrics/pom.xml
+++ b/metrics/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>microservice-framework</artifactId>
         <groupId>uk.gov.justice.services</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
 
     <groupId>uk.gov.justice.metrics</groupId>

--- a/microservices-framework-version/pom.xml
+++ b/microservices-framework-version/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>uk.gov.justice.services</groupId>
         <artifactId>microservice-framework</artifactId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
 
     <artifactId>microservices-framework-version</artifactId>

--- a/persistence/persistence-deltaspike/pom.xml
+++ b/persistence/persistence-deltaspike/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>persistence</artifactId>
         <groupId>uk.gov.justice.services</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/persistence/persistence-jdbc/pom.xml
+++ b/persistence/persistence-jdbc/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>persistence</artifactId>
         <groupId>uk.gov.justice.services</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/persistence/pom.xml
+++ b/persistence/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>microservice-framework</artifactId>
         <groupId>uk.gov.justice.services</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,12 +7,12 @@
     <parent>
         <groupId>uk.gov.justice</groupId>
         <artifactId>maven-framework-parent-pom</artifactId>
-        <version>21.0.0-M3</version>
+        <version>25.104.0-M3</version>
     </parent>
 
     <groupId>uk.gov.justice.services</groupId>
     <artifactId>microservice-framework</artifactId>
-    <version>21.0.0-M1-SNAPSHOT</version>
+    <version>25.104.0-M1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Microservice Framework</name>
@@ -47,7 +47,9 @@
     
     <properties>
         <cpp.repo.name>microservice_framework</cpp.repo.name>
-        <framework-libraries.version>21.0.0-M1-SNAPSHOT</framework-libraries.version>
+        <framework-libraries.version>25.104.0-M6</framework-libraries.version>
+        <!-- liquibase-maven-plugin: 4.24–4.29 have mojo loading failures (LOG_FORMAT removed, AbstractLogger API break); pin to 4.10.0 which pre-dates the refactoring -->
+        <liquibase.maven.plugin.version>4.10.0</liquibase.maven.plugin.version>
         <!--
             jakarta.xml.bind-api is managed by the BOM at 4.0.0 (Jakarta EE 10,
             namespace jakarta.xml.bind.*). The RAML parser (org.raml:raml-parser)

--- a/pom.xml
+++ b/pom.xml
@@ -172,6 +172,14 @@
                 <configuration>
                     <skip>true</skip>
                 </configuration>
+                <dependencies>
+                    <!-- coveralls-maven-plugin 4.3.0 ships with jakarta.xml.bind-api:2.3.1 which is unavailable in the CI repo. Pin to 2.3.2. -->
+                    <dependency>
+                        <groupId>jakarta.xml.bind</groupId>
+                        <artifactId>jakarta.xml.bind-api</artifactId>
+                        <version>${jakarta.xml.bind-api.raml.version}</version>
+                    </dependency>
+                </dependencies>
             </plugin>
         </plugins>
     </build>

--- a/raml-lint-check/lint-check-rules/pom.xml
+++ b/raml-lint-check/lint-check-rules/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>raml-lint-check</artifactId>
         <groupId>uk.gov.justice.framework-generators</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>jar</packaging>

--- a/raml-lint-check/pom.xml
+++ b/raml-lint-check/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>microservice-framework</artifactId>
         <groupId>uk.gov.justice.services</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/test-utils/integration-test-utils-jms/pom.xml
+++ b/test-utils/integration-test-utils-jms/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>uk.gov.justice.services</groupId>
         <artifactId>test-utils</artifactId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
 
     <groupId>uk.gov.justice.utils</groupId>
@@ -15,7 +15,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-jakarta-client</artifactId>
         </dependency>
         <dependency>

--- a/test-utils/pom.xml
+++ b/test-utils/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>microservice-framework</artifactId>
         <groupId>uk.gov.justice.services</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/test-utils/test-utils-common/pom.xml
+++ b/test-utils/test-utils-common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>test-utils</artifactId>
         <groupId>uk.gov.justice.services</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/test-utils/test-utils-core/pom.xml
+++ b/test-utils/test-utils-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>uk.gov.justice.services</groupId>
         <artifactId>test-utils</artifactId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -49,7 +49,7 @@
             <artifactId>resteasy-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-jakarta-client</artifactId>
         </dependency>
         <dependency>

--- a/test-utils/test-utils-enveloper-provider/pom.xml
+++ b/test-utils/test-utils-enveloper-provider/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>test-utils</artifactId>
         <groupId>uk.gov.justice.services</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/test-utils/test-utils-framework-persistence/pom.xml
+++ b/test-utils/test-utils-framework-persistence/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>test-utils</artifactId>
         <groupId>uk.gov.justice.services</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/test-utils/test-utils-jmx/pom.xml
+++ b/test-utils/test-utils-jmx/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>test-utils</artifactId>
         <groupId>uk.gov.justice.services</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/test-utils/test-utils-messaging/pom.xml
+++ b/test-utils/test-utils-messaging/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>test-utils</artifactId>
         <groupId>uk.gov.justice.services</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
## Java 25 / WildFly 40 spike — cp-microservice-framework

Spike to prove viability of skipping Java 21 and going straight to **Java 25 / WildFly 40 / Jakarta EE 11**.

**Spike gate: cp-cake-shop integration tests — 42/42 passing ✅**

Version series: `25.104.0-M1-SNAPSHOT` — the middle number preserves the framework-E lineage (104), 25 = Java version.

### Changes
- Version bumped to `25.104.0-M1-SNAPSHOT`
- Parent chain updated to `cp-maven-framework-parent-pom:25.104.0-M1-SNAPSHOT`
- **Jackson 2.21 API change:** `EnumResolver.constructFor()` and `constructUsingToString()` now take `AnnotatedClass` instead of `Class<?>` — fixed by passing `beanDesc.getClassInfo()`
- **JAX-RS 4.0 (Jakarta EE 11):** `HttpHeaders.containsHeaderString(String, String, Predicate<String>)` is now abstract — anonymous `HttpHeaders` implementations updated
- `resteasy-jaxrs` artifact removed from RESTEasy 7.x — replaced by `resteasy-core`; `cdi-unit:4.0.1` internal dependency continues to resolve its own `resteasy-jaxrs:3.0.14.Final` without issue
- Test scope: `org.glassfish:jakarta.json` replaced with `org.eclipse.parsson:parsson`
- `coveralls-maven-plugin`: `jakarta.xml.bind-api` pinned to `2.3.2` in plugin dependencies

### ⚠️ CI
CIs will fail until Java 25 build pipelines are created. **Do not merge until CI is green.**

### Related PRs (full spike chain)
cp-maven-super-pom → cp-maven-parent-pom → cp-maven-common-bom → cp-maven-framework-parent-pom → cp-file-service → cp-wiremock-service → cp-framework-libraries → cp-microservice-framework → cp-event-store → cp-cake-shop